### PR TITLE
Implemented HTML templating for report generation in GenerateReport function

### DIFF
--- a/services/email.go
+++ b/services/email.go
@@ -1,18 +1,20 @@
 package services
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"net/smtp"
+	"text/template"
 )
 
-func SendReport(report string) {
+func SendReport(report EmailData) {
 	config, err := LoadConfig()
 	if err != nil {
 		log.Fatalf("Error loading configuration: %s", err)
 	}
 
-	mail := composeEmail(report, config)
+	mail := composeEmail(report)
 
 	err = sendEmail(mail, config)
 	if err != nil {
@@ -23,12 +25,25 @@ func SendReport(report string) {
 	log.Print("Email sent successfully")
 }
 
-func composeEmail(report string, config *Config) string {
-	return fmt.Sprintf("From: %s\nTo: %s\nSubject: Weekly Pull Request Summary\n\n%s", config.GmailUsername, config.GmailUsername, report)
+func composeEmail(report EmailData) bytes.Buffer {
+  t, err := template.ParseFiles("services/template.html")
+  if err != nil {
+      log.Fatalf("Error parsing template: %s", err)
+  }
+
+  var body bytes.Buffer
+  mimeHeaders := "MIME-version: 1.0;\nContent-Type: text/html; charset=\"UTF-8\";\n\n"
+  body.Write([]byte(fmt.Sprintf("Subject: Weekly Pull Request Summary\n%s\n\n", mimeHeaders)))
+
+  if err := t.Execute(&body, report); err != nil {
+      log.Fatalf("Error executing template: %s", err)
+  }
+  return body
 }
 
-func sendEmail(mail string, config *Config) error {
+func sendEmail(mail bytes.Buffer, config *Config) error {
 	auth := smtp.PlainAuth("", config.GmailUsername, config.GmailToken, "smtp.gmail.com")
-	err := smtp.SendMail("smtp.gmail.com:587", auth, config.GmailUsername, []string{config.GmailUsername}, []byte(mail))
+	
+  err := smtp.SendMail("smtp.gmail.com:587", auth, config.GmailUsername, []string{config.GmailUsername}, mail.Bytes())
 	return err
 }

--- a/services/template.html
+++ b/services/template.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Pull Request Summary</title>
+</head>
+<body>
+    <h2>{{.Repo}} Pull Request Summary</h2>
+    <p>Opened: {{.Opened}}</p>
+    <p>Closed: {{.Closed}}</p>
+    <p>In Progress: {{.InProgress}}</p>
+    <hr>
+    <h3>Opened Pull Requests:</h3>
+    <ul>
+        {{range .OpenPullRequests}}
+            <li>
+                <strong>#{{.Number}}:</strong> "{{.Title}}" by {{.Author}} ({{.Date}})
+            </li>
+        {{end}}
+    </ul>
+    <hr>
+    <h3>Closed Pull Requests:</h3>
+    <ul>
+        {{range .ClosedPullRequests}}
+            <li>
+                <strong>#{{.Number}}:</strong> "{{.Title}}" by {{.Author}} ({{.Date}})
+            </li>
+        {{end}}
+    </ul>
+    <hr>
+    <p>Please review and take necessary actions.</p>
+    <p>Best regards,<br>Your Name</p>
+</body>
+</html>
+


### PR DESCRIPTION
This PR introduces changes to the GenerateReport function to utilize Go's HTML templating for generating reports. 
The function now produces an HTML report summarizing pull request activities for a given GitHub repository over the last week. 
It defines two structs, PullRequestData and ReportData, to organize the data efficiently. 
The HTML template includes placeholders for dynamic data such as the repository name, counts of opened, closed, and in-progress pull requests, as well as lists of opened and closed pull requests with their respective details.
