### PR TITLE
Added URLs to pull requests in the HTML report template

### DIFF
--- a/services/email.go
+++ b/services/email.go
@@ -26,24 +26,24 @@ func SendReport(report EmailData) {
 }
 
 func composeEmail(report EmailData) bytes.Buffer {
-  t, err := template.ParseFiles("services/template.html")
-  if err != nil {
-      log.Fatalf("Error parsing template: %s", err)
-  }
+	t, err := template.ParseFiles("services/template.html")
+	if err != nil {
+		log.Fatalf("Error parsing template: %s", err)
+	}
 
-  var body bytes.Buffer
-  mimeHeaders := "MIME-version: 1.0;\nContent-Type: text/html; charset=\"UTF-8\";\n\n"
-  body.Write([]byte(fmt.Sprintf("Subject: Weekly Pull Request Summary\n%s\n\n", mimeHeaders)))
+	var body bytes.Buffer
+	mimeHeaders := "MIME-version: 1.0;\nContent-Type: text/html; charset=\"UTF-8\";\n\n"
+	body.Write([]byte(fmt.Sprintf("Subject: Weekly Pull Request Summary\n%s\n\n", mimeHeaders)))
 
-  if err := t.Execute(&body, report); err != nil {
-      log.Fatalf("Error executing template: %s", err)
-  }
-  return body
+	if err := t.Execute(&body, report); err != nil {
+		log.Fatalf("Error executing template: %s", err)
+	}
+	return body
 }
 
 func sendEmail(mail bytes.Buffer, config *Config) error {
 	auth := smtp.PlainAuth("", config.GmailUsername, config.GmailToken, "smtp.gmail.com")
-	
-  err := smtp.SendMail("smtp.gmail.com:587", auth, config.GmailUsername, []string{config.GmailUsername}, mail.Bytes())
+
+	err := smtp.SendMail("smtp.gmail.com:587", auth, config.GmailUsername, []string{config.GmailUsername}, mail.Bytes())
 	return err
 }

--- a/services/report.go
+++ b/services/report.go
@@ -12,28 +12,27 @@ import (
 	"golang.org/x/oauth2"
 )
 
-
 type PullRequest struct {
-    Number int
-    Title  string
-    Author string
-    Date   string
+	Number int
+	Title  string
+	Author string
+	Date   string
+	URL    string
 }
 
 type EmailData struct {
-    Repo             string
-    Opened           int
-    Closed           int
-    InProgress       int
-    OpenPullRequests []PullRequest
-    ClosedPullRequests []PullRequest
+	Repo               string
+	Opened             int
+	Closed             int
+	InProgress         int
+	OpenPullRequests   []PullRequest
+	ClosedPullRequests []PullRequest
 }
 
 var openPullRequests []PullRequest
 var closedPullRequests []PullRequest
 
-
-func GenerateReport() (EmailData) {
+func GenerateReport() EmailData {
 	config, err := LoadConfig()
 	if err != nil {
 		log.Fatalf("Error loading configuration: %s", err)
@@ -84,34 +83,36 @@ func GenerateReport() (EmailData) {
 		}
 	}
 
-    for _, pr := range repos {
-        if *pr.State == "open" {
-            appendPR(pr, "open")
-            openPullRequests = append(openPullRequests, PullRequest{
-                Number: *pr.Number,
-                Title:  *pr.Title,
-                Author: *pr.User.Login,
-                Date:   pr.CreatedAt.Format("January 2, 2006"),
-            })
-        } else if *pr.State == "closed" {
-            appendPR(pr, "closed")
-            closedPullRequests = append(closedPullRequests, PullRequest{
-                Number: *pr.Number,
-                Title:  *pr.Title,
-                Author: *pr.User.Login,
-                Date:   pr.ClosedAt.Format("January 2, 2006"),
-            })
-        }
-    }
+	for _, pr := range repos {
+		if *pr.State == "open" {
+			appendPR(pr, "open")
+			openPullRequests = append(openPullRequests, PullRequest{
+				Number: *pr.Number,
+				Title:  *pr.Title,
+				Author: *pr.User.Login,
+				Date:   pr.CreatedAt.Format("January 2, 2006"),
+				URL:    *pr.HTMLURL,
+			})
+		} else if *pr.State == "closed" {
+			appendPR(pr, "closed")
+			closedPullRequests = append(closedPullRequests, PullRequest{
+				Number: *pr.Number,
+				Title:  *pr.Title,
+				Author: *pr.User.Login,
+				Date:   pr.ClosedAt.Format("January 2, 2006"),
+				URL:    *pr.HTMLURL,
+			})
+		}
+	}
 
-    emailData := EmailData{
-        Repo:               githubRepo,
-        Opened:             open,
-        Closed:             closed,
-        InProgress:         inProgress,
-        OpenPullRequests:   openPullRequests,
-        ClosedPullRequests: closedPullRequests,
-    }
+	emailData := EmailData{
+		Repo:               githubRepo,
+		Opened:             open,
+		Closed:             closed,
+		InProgress:         inProgress,
+		OpenPullRequests:   openPullRequests,
+		ClosedPullRequests: closedPullRequests,
+	}
 
 	return emailData
 }

--- a/services/template.html
+++ b/services/template.html
@@ -5,7 +5,7 @@
     <title>Pull Request Summary</title>
 </head>
 <body>
-    <h2>{{.Repo}} Pull Request Summary</h2>
+    <h2>Pull Request Summary for {{.Repo}}</h2>
     <p>Opened: {{.Opened}}</p>
     <p>Closed: {{.Closed}}</p>
     <p>In Progress: {{.InProgress}}</p>
@@ -14,7 +14,7 @@
     <ul>
         {{range .OpenPullRequests}}
             <li>
-                <strong>#{{.Number}}:</strong> "{{.Title}}" by {{.Author}} ({{.Date}})
+                <strong>#{{.Number}}:</strong> "<a href="{{.URL}}">{{.Title}}</a>" by {{.Author}} (Opened on {{.Date}})
             </li>
         {{end}}
     </ul>
@@ -23,13 +23,13 @@
     <ul>
         {{range .ClosedPullRequests}}
             <li>
-                <strong>#{{.Number}}:</strong> "{{.Title}}" by {{.Author}} ({{.Date}})
+                <strong>#{{.Number}}:</strong> "<a href="{{.URL}}">{{.Title}}</a>" by {{.Author}} (Closed on {{.Date}})
             </li>
         {{end}}
     </ul>
     <hr>
     <p>Please review and take necessary actions.</p>
-    <p>Best regards,<br>Your Name</p>
+    <p>Best regards</p>
 </body>
 </html>
 


### PR DESCRIPTION
This PR updates the HTML template used in the GenerateReport function to include URLs for pull requests.

Each pull request title in the report now serves as a clickable link, directing users to the respective pull request on GitHub. This improvement enhances the readability and usability of the generated report, providing easier access to detailed information about each pull request.
